### PR TITLE
opa-react: set 'browser' (not only 'main') in package.json

### DIFF
--- a/.changeset/tidy-cooks-flow.md
+++ b/.changeset/tidy-cooks-flow.md
@@ -1,0 +1,7 @@
+---
+"@styra/opa-react": patch
+---
+
+Fix package.json (add "browser" next to "main")
+
+Before, create-react-app (or webpack, rather) failed to resolve @styra/opa-react.

--- a/packages/opa-react/package.json
+++ b/packages/opa-react/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
+  "browser": "./dist/cjs/index.js",
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {


### PR DESCRIPTION
> If your module is meant to be used client-side the browser field should be used instead of the main field.

💯 