### PR TITLE
releng: build packages before publishing them

### DIFF
--- a/.changeset/fast-dolphins-reflect.md
+++ b/.changeset/fast-dolphins-reflect.md
@@ -1,0 +1,5 @@
+---
+"@styra/opa-react": patch
+---
+
+build packages when publishing

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-packages",
   "scripts": {
-    "publish": "changeset publish"
+    "publish": "npm run build --ws && changeset publish"
   },
   "private": true,
   "workspaces": ["./packages/opa-react"],


### PR DESCRIPTION
I had assumed that changeset does that -- but on closer inspection, it does not. So now we should end up with a dist/ folder in our NPM tarballs.