### PR TITLE
opa: fix "see repo" link

### DIFF
--- a/packages/opa/typedoc.config.cjs
+++ b/packages/opa/typedoc.config.cjs
@@ -49,7 +49,7 @@ module.exports = {
         pattern:
           "For supported JavaScript runtimes, please consult \\[RUNTIMES\\.md\\]\\(RUNTIMES\\.md\\)\\.",
         replace:
-          "See [the repository docs](https://github.com/StyraInc/opa-typescript/blob/main/RUNTIMES.md) for supported JavaScript runtimes.",
+          "See [the repository docs](https://github.com/StyraInc/ts-packages/blob/main/packages/opa/RUNTIMES.md) for supported JavaScript runtimes.",
       },
     ],
   },


### PR DESCRIPTION
This is temporary -- we'll rename 'ts-packages' => 'opa-typescript' soon.